### PR TITLE
Add Azure environment and Armstrong number tests

### DIFF
--- a/.github/workflows/api-tests-bruno.yaml
+++ b/.github/workflows/api-tests-bruno.yaml
@@ -1,0 +1,28 @@
+# This workflow runs the API tests for the bruno application on the latest version of Ubuntu
+
+name: API Tests - Bruno
+
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  run_bruno_api_test:
+    name: API Tests by Bruno
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies and run tests
+        run: |
+          npm install
+          npm run test
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()          # run this step even if previous step failed
+        with:
+          name: Bruno API Tests             # Name of the check run which will be created
+          path: report.xml            # Path to test results
+          reporter: java-junit              # Format of test results

--- a/exercism-api-tests/armstrong-numbers/Single digits are Armstrong numbers.bru
+++ b/exercism-api-tests/armstrong-numbers/Single digits are Armstrong numbers.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Single digits are Armstrong numbers
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=5
+  body: none
+  auth: none
+}
+
+query {
+  number: 5
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy 
+}

--- a/exercism-api-tests/armstrong-numbers/Zero is Armstrong numbers.bru
+++ b/exercism-api-tests/armstrong-numbers/Zero is Armstrong numbers.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Zero is Armstrong numbers
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=0
+  body: none
+  auth: none
+}
+
+query {
+  number: 0
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy 
+}

--- a/exercism-api-tests/bruno.json
+++ b/exercism-api-tests/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "Exercism Azure Functions",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/exercism-api-tests/environments/azure.bru
+++ b/exercism-api-tests/environments/azure.bru
@@ -1,0 +1,3 @@
+vars {
+  host: https://exercism.azurewebsites.net
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bruno API tests for Azure functions",
   "main": "index.js",
   "scripts": {
-    "test": "bru run --env azure --format junit --output report.xml"
+    "test": "cd exercism-api-tests && bru run --env azure --format junit --output ../report.xml"
   },
   "keywords": [
     "bruno",


### PR DESCRIPTION
Introduced an Azure environment for the exercism API tests. Furthermore, added new test cases for Armstrong numbers (specifically, the number zero and single digits). These tests are designed to check HTTP responses from queries involving these numbers. The test script path has also been updated in package.json.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced API tests for the Bruno application, including tests for Armstrong numbers and configuration for Azure environments.
- **Tests**
	- Added workflows to run API tests on Ubuntu, ensuring code quality and functionality.
- **Chores**
	- Updated the `test` script in `package.json` for enhanced test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->