### PR TITLE
Add new Armstrong number tests

### DIFF
--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: A seven digit number that is an Armstrong number
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=9926315
+  body: none
+  auth: none
+}
+
+query {
+  number: 9926315
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy 
+}

--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: A seven digit number that is an Armstrong number
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=9926315
+  body: none
+  auth: none
+}
+
+query {
+  number: 9926314
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy 
+}

--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
@@ -1,5 +1,5 @@
 meta {
-  name: A seven digit number that is an Armstrong number
+  name: A seven digit number that is not an Armstrong number
   type: http
   seq: 4
 }

--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
@@ -15,5 +15,5 @@ query {
 }
 
 assert {
-  res.body.isArmstrongNumber: isTruthy 
+  res.body.isArmstrongNumber: isFalsy
 }

--- a/exercism-api-tests/Armstrong Numbers/Error when number is not specified.bru
+++ b/exercism-api-tests/Armstrong Numbers/Error when number is not specified.bru
@@ -1,0 +1,17 @@
+meta {
+  name: Error when number is not specified
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 400
+  res.body.message: isDefined
+  res.body.message: contains pass a number
+}

--- a/exercism-api-tests/Armstrong Numbers/Single digits are Armstrong numbers.bru
+++ b/exercism-api-tests/Armstrong Numbers/Single digits are Armstrong numbers.bru
@@ -15,5 +15,5 @@ query {
 }
 
 assert {
-  res.body.isArmstrongNumber: isTruthy 
+  res.body.isArmstrongNumber: isTruthy
 }

--- a/exercism-api-tests/Armstrong Numbers/There are no two digit Armstrong numbers.bru
+++ b/exercism-api-tests/Armstrong Numbers/There are no two digit Armstrong numbers.bru
@@ -1,0 +1,19 @@
+meta {
+  name: There are no two digit Armstrong numbers
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=10
+  body: none
+  auth: none
+}
+
+query {
+  number: 10
+}
+
+assert {
+  res.body.isArmstrongNumber: isFalsy 
+}

--- a/exercism-api-tests/Armstrong Numbers/Zero is Armstrong numbers.bru
+++ b/exercism-api-tests/Armstrong Numbers/Zero is Armstrong numbers.bru
@@ -15,5 +15,5 @@ query {
 }
 
 assert {
-  res.body.isArmstrongNumber: isTruthy 
+  res.body.isArmstrongNumber: isTruthy
 }


### PR DESCRIPTION
Added several new test cases for Armstrong numbers to the exercism API tests suite. This includes checks for a seven digit Armstrong number, error scenarios when number is not specified, a seven digit number that's not Armstrong, and when there are no two digit Armstrong numbers. This will enhance the test coverage and ensure the robustness of the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced test cases for verifying seven-digit Armstrong numbers.
	- Added a test case to ensure single-digit numbers are recognized as Armstrong numbers.
	- Implemented a test to confirm that there are no two-digit Armstrong numbers.
	- Validated through testing that zero is considered an Armstrong number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->