### PR TITLE
Update sequence numbers and add new Armstrong number tests

### DIFF
--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is an Armstrong number.bru
@@ -1,7 +1,7 @@
 meta {
   name: A seven digit number that is an Armstrong number
   type: http
-  seq: 4
+  seq: 8
 }
 
 get {
@@ -15,5 +15,5 @@ query {
 }
 
 assert {
-  res.body.isArmstrongNumber: isTruthy 
+  res.body.isArmstrongNumber: isTruthy
 }

--- a/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/A seven digit number that is not an Armstrong number.bru
@@ -1,11 +1,11 @@
 meta {
-  name: A seven digit number that is an Armstrong number
+  name: A seven digit number that is not an Armstrong number
   type: http
-  seq: 4
+  seq: 9
 }
 
 get {
-  url: {{host}}/api/armstrong-numbers?number=9926315
+  url: {{host}}/api/armstrong-numbers?number=9926314
   body: none
   auth: none
 }
@@ -15,5 +15,5 @@ query {
 }
 
 assert {
-  res.body.isArmstrongNumber: isTruthy 
+  res.body.isArmstrongNumber: isFalsy
 }

--- a/exercism-api-tests/Armstrong Numbers/Error when number is not specified.bru
+++ b/exercism-api-tests/Armstrong Numbers/Error when number is not specified.bru
@@ -1,7 +1,7 @@
 meta {
   name: Error when number is not specified
   type: http
-  seq: 5
+  seq: 10
 }
 
 get {

--- a/exercism-api-tests/Armstrong Numbers/Four-digit number that is an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/Four-digit number that is an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Four-digit number that is an Armstrong number
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=9474
+  body: none
+  auth: none
+}
+
+query {
+  number: 9474
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy
+}

--- a/exercism-api-tests/Armstrong Numbers/Four-digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/Four-digit number that is not an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Four-digit number that is not an Armstrong number
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=9475
+  body: none
+  auth: none
+}
+
+query {
+  number: 9475
+}
+
+assert {
+  res.body.isArmstrongNumber: isFalsy
+}

--- a/exercism-api-tests/Armstrong Numbers/Three-digit number that is an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/Three-digit number that is an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Three-digit number that is an Armstrong number
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=153
+  body: none
+  auth: none
+}
+
+query {
+  number: 153
+}
+
+assert {
+  res.body.isArmstrongNumber: isTruthy
+}

--- a/exercism-api-tests/Armstrong Numbers/Three-digit number that is not an Armstrong number.bru
+++ b/exercism-api-tests/Armstrong Numbers/Three-digit number that is not an Armstrong number.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Three-digit number that is not an Armstrong number
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{host}}/api/armstrong-numbers?number=100
+  body: none
+  auth: none
+}
+
+query {
+  number: 100
+}
+
+assert {
+  res.body.isArmstrongNumber: isFalsy
+}


### PR DESCRIPTION
Sequence numbers have been updated in 'A seven digit number that is an Armstrong number.bru', 'Error when number is not specified.bru' and 'A seven digit number that is not an Armstrong number.bru' files. Besides, new Armstrong number test scenarios have been introduced for three-digit and four-digit numbers. These changes will help refine test flow and improve the overall test coverage of the Armstrong numbers' functionality in the API.

@coderabbitai ignore