### PR TITLE
Add new test cases for change-making algorithm

### DIFF
--- a/.github/workflows/api-tests-change.yaml
+++ b/.github/workflows/api-tests-change.yaml
@@ -1,0 +1,28 @@
+# This workflow runs the API tests for the bruno application on the latest version of Ubuntu
+
+name: API Tests - Change
+
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  run_change_api_test:
+    name: API Tests - Change
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies and run tests
+        run: |
+          npm install
+          npm run change
+
+      - name: Publish Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure()          # run this step even if previous step failed
+        with:
+          name: Change API Tests             # Name of the check run which will be created
+          path: report.xml                  # Path to test results
+          reporter: java-junit              # Format of test results

--- a/exercism-api-tests/Change/a greedy approach is not optimal.bru
+++ b/exercism-api-tests/Change/a greedy approach is not optimal.bru
@@ -1,0 +1,43 @@
+meta {
+  name: a greedy approach is not optimal
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 10, 11],
+    "target": 20
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 2
+  res.body.fewestCoins: contains 10
+}
+
+docs {
+  ### A Greedy Approach is Not Optimal Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario where **a greedy approach is not optimal**.
+
+  - **Input**: A list of coins `[1, 10, 11]` and a target amount of `20`.
+  - **Expected Output**: An array containing two coins of value `10`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `2`, and contains the coin of value `10`.
+}

--- a/exercism-api-tests/Change/another possible change without unit coins available.bru
+++ b/exercism-api-tests/Change/another possible change without unit coins available.bru
@@ -1,0 +1,44 @@
+meta {
+  name: another possible change without unit coins available
+  type: http
+  seq: 8
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [4, 5],
+    "target": 27
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined 
+  res.body.fewestCoins: length 6
+  res.body.fewestCoins: contains 4
+  res.body.fewestCoins: contains 5
+}
+
+docs {
+  ### Another Possible Change Without Unit Coins Available Test Case
+
+  This test case verifies the functionality of the change-making algorithm with another scenario where **unit coins are not available**. 
+
+  - **Input**: A list of coins `[4, 5]` and a target amount of `27`. 
+  - **Expected Output**: An array containing six coins of values `4`, `4`, `4`, `5`, `5`, `5`, which is the fewest number of coins that sum up to the target amount. 
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `6`, and contains the coins of values `4` and `5`.
+}

--- a/exercism-api-tests/Change/cannot find negative change values.bru
+++ b/exercism-api-tests/Change/cannot find negative change values.bru
@@ -1,0 +1,42 @@
+meta {
+  name: cannot find negative change values
+  type: http
+  seq: 13
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 2, 5],
+    "target": -5
+  }
+}
+
+assert {
+  res.status: eq 400
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.error: isDefined
+  res.body.error: eq Negative change not allowed
+}
+
+docs {
+  ### Cannot Find Negative Change Values Test Case
+  
+  This test case verifies the functionality of the change-making algorithm with a scenario where **the target is negative**.
+  
+  - **Input**: A list of coins `[1, 2, 5]` and a target amount of `-5`.
+  - **Expected Output**: An error message stating "target can't be negative".
+  
+  The assertions in this test ensure that:
+  
+  - The API response status is `400`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'error' field in the response body is defined and equals "target can't be negative".
+}

--- a/exercism-api-tests/Change/change for 1 cent.bru
+++ b/exercism-api-tests/Change/change for 1 cent.bru
@@ -1,0 +1,61 @@
+meta {
+  name: change for 1 cent
+  type: http
+  seq: 0
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 5, 10, 25],
+    "target": 1
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 1
+  res.body.fewestCoins: contains 1
+}
+
+tests {
+  test("Response status code is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("Response has the required Content-Type header with value application/json", function() {
+    expect(res.getHeaders().get("Content-Type")).to.include("application/json");
+  });
+  
+  test("Validate the structure of the fewestCoins array", function() {
+    const data = res.getBody();
+    
+    expect(data).to.be.an('object');
+    expect(data.fewestCoins).to.be.an('array');
+  });
+  
+  test("FewestCoins array is present and contains at least one element", function() {
+    const data = res.getBody();
+    
+    expect(data).to.be.an('object');
+    expect(data.fewestCoins).to.exist.and.to.be.an('array').that.is.not.empty;
+  });
+  
+  test("Ensure that the value within the 'fewestCoins' array is a non-negative integer", function() {
+    const data = res.getBody();
+    
+    expect(data).to.be.an('object');
+    expect(data.fewestCoins).to.be.an('array');
+    data.fewestCoins.forEach(function (coin) {
+      expect(coin).to.be.a('number').and.to.satisfy((num) => num >= 0);
+    });
+  });
+}

--- a/exercism-api-tests/Change/change with Lilliputian Coins.bru
+++ b/exercism-api-tests/Change/change with Lilliputian Coins.bru
@@ -1,0 +1,44 @@
+meta {
+  name: change with Lilliputian Coins
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 4, 15, 20, 50],
+    "target": 23
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 3
+  res.body.fewestCoins: contains 4
+  res.body.fewestCoins: contains 15
+}
+
+docs {
+  ### Change with Lilliputian Coins Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario involving **Lilliputian coins**.
+
+  - **Input**: A list of coins `[1, 4, 15, 20, 50]` and a target amount of `23`.
+  - **Expected Output**: An array containing three coins of values `4`, `4`, and `15`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `3`, and contains the coins of values `4` and `15`.
+}

--- a/exercism-api-tests/Change/change with Lower Elbonia Coins.bru
+++ b/exercism-api-tests/Change/change with Lower Elbonia Coins.bru
@@ -1,0 +1,43 @@
+meta {
+  name: change with Lower Elbonia Coins
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 5, 10, 21, 25],
+    "target": 63
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 3
+  res.body.fewestCoins: contains 21
+}
+
+docs {
+  ### Change with Lower Elbonia Coins Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario involving **Lower Elbonia coins**.
+
+  - **Input**: A list of coins `[1, 5, 10, 21, 25]` and a target amount of `63`.
+  - **Expected Output**: An array containing three coins of value `21`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `3`, and contains the coin of value `21`.
+}

--- a/exercism-api-tests/Change/error if no combination can add up to target.bru
+++ b/exercism-api-tests/Change/error if no combination can add up to target.bru
@@ -1,0 +1,42 @@
+meta {
+  name: error if no combination can add up to target
+  type: http
+  seq: 12
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [5, 10],
+    "target": 94
+  }
+}
+
+assert {
+  res.status: eq 400
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.error: isDefined
+  res.body.error: eq "can't make target with given coins"
+}
+
+docs {
+  ### Error if No Combination Can Add Up to Target Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario where **no combination of coins can add up to the target**.
+
+  - **Input**: A list of coins `[5, 10]` and a target amount of `94`.
+  - **Expected Output**: An error message stating "can't make target with given coins".
+
+  The assertions in this test ensure that:
+
+  - The API response status is `400`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'error' field in the response body is defined and equals "can't make target with given coins".
+}

--- a/exercism-api-tests/Change/error testing for change smaller than the smallest of coins.bru
+++ b/exercism-api-tests/Change/error testing for change smaller than the smallest of coins.bru
@@ -1,0 +1,42 @@
+meta {
+  name: error testing for change smaller than the smallest of coins
+  type: http
+  seq: 11
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [5, 10],
+    "target": 3
+  }
+}
+
+assert {
+  res.status: eq 400
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.error: isDefined
+  res.body.error: eq "can't make target with given coins"
+}
+
+docs {
+  ### Error Testing for Change Smaller Than the Smallest of Coins Test Case
+  
+  This test case verifies the functionality of the change-making algorithm with a scenario where **the target is smaller than the smallest of coins**.
+  
+  - **Input**: A list of coins `[5, 10]` and a target amount of `3`.
+  - **Expected Output**: An error message stating "can't make target with given coins".
+  
+  The assertions in this test ensure that:
+  
+  - The API response status is `400`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'error' field in the response body is defined and equals "can't make target with given coins".
+}

--- a/exercism-api-tests/Change/large target values.bru
+++ b/exercism-api-tests/Change/large target values.bru
@@ -1,0 +1,47 @@
+meta {
+  name: large target values
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 2, 5, 10, 20, 50, 100],
+    "target": 999
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 15
+  res.body.fewestCoins: contains 2
+  res.body.fewestCoins: contains 5
+  res.body.fewestCoins: contains 20
+  res.body.fewestCoins: contains 50
+  res.body.fewestCoins: contains 100
+}
+
+docs {
+  ### Large Target Values Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario involving **large target values**.
+
+  - **Input**: A list of coins `[1, 2, 5, 10, 20, 50, 100]` and a target amount of `999`.
+  - **Expected Output**: An array containing fifteen coins of values `2`, `2`, `5`, `20`, `20`, `50`, `100`, `100`, `100`, `100`, `100`, `100`, `100`, `100`, `100`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `15`, and contains the coins of values `2`, `5`, `20`, `50`, and `100`.
+}

--- a/exercism-api-tests/Change/multiple coin change.bru
+++ b/exercism-api-tests/Change/multiple coin change.bru
@@ -1,0 +1,44 @@
+meta {
+  name: multiple coin change
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 5, 10, 25, 100],
+    "target": 15
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 2
+  res.body.fewestCoins: contains 5
+  res.body.fewestCoins: contains 10
+}
+
+docs {
+  ### Multiple Coin Change Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a **multiple coin change** scenario.
+
+  - **Input**: A list of coins `[1, 5, 10, 25, 100]` and a target amount of `15`.
+  - **Expected Output**: An array containing two coins of values `5` and `10`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `2`, and contains the coins of values `5` and `10`.
+}

--- a/exercism-api-tests/Change/no coins make 0 change.bru
+++ b/exercism-api-tests/Change/no coins make 0 change.bru
@@ -1,0 +1,42 @@
+meta {
+  name: no coins make 0 change
+  type: http
+  seq: 10
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 5, 10, 21, 25],
+    "target": 0
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined 
+  res.body.fewestCoins: length 0
+}
+
+docs {
+  ### No Coins Make 0 Change Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario where **no coins make 0 change**. 
+
+  - **Input**: A list of coins `[1, 5, 10, 21, 25]` and a target amount of `0`. 
+  - **Expected Output**: An empty array, as no coins are needed to make 0 change. 
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined and has a length of `0`.
+}

--- a/exercism-api-tests/Change/possible change without unit coins available.bru
+++ b/exercism-api-tests/Change/possible change without unit coins available.bru
@@ -1,0 +1,45 @@
+meta {
+  name: possible change without unit coins available
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [2, 5, 10, 20, 50],
+    "target": 21
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 5
+  res.body.fewestCoins: contains 2
+  res.body.fewestCoins: contains 5
+  res.body.fewestCoins: contains 10
+}
+
+docs {
+  ### Possible Change Without Unit Coins Available Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a scenario where **unit coins are not available**.
+
+  - **Input**: A list of coins `[2, 5, 10, 20, 50]` and a target amount of `21`.
+  - **Expected Output**: An array containing five coins of values `2`, `2`, `2`, `5`, `10`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `5`, and contains the coins of values `2`, `5`, and `10`.
+}

--- a/exercism-api-tests/Change/single coin change.bru
+++ b/exercism-api-tests/Change/single coin change.bru
@@ -1,0 +1,43 @@
+meta {
+  name: single coin change
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{host}}/api/change
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "coins": [1, 5, 10, 25, 100],
+    "target": 25
+  }
+}
+
+assert {
+  res.status: eq 200
+  res.headers['content-type']: contains application/json
+  res.body: isJson
+  res.body.fewestCoins: isDefined
+  res.body.fewestCoins: length 1
+  res.body.fewestCoins: contains 25
+}
+
+docs {
+  ### Single Coin Change Test Case
+
+  This test case verifies the functionality of the change-making algorithm with a **single coin change** scenario.
+
+  - **Input**: A list of coins `[1, 5, 10, 25, 100]` and a target amount of `25`.
+  - **Expected Output**: An array containing a single coin of value `25`, which is the fewest number of coins that sum up to the target amount.
+
+  The assertions in this test ensure that:
+
+  - The API response status is `200`
+  - The `Content-Type` header is `application/json`
+  - The response body is a valid JSON
+  - The 'fewestCoins' array in the response body is defined, has a length of `1`, and contains the coin of value `25`.
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Bruno API tests for Azure functions",
   "main": "index.js",
   "scripts": {
-    "test": "cd exercism-api-tests && bru run --env azure --format junit --output ../report.xml"
+    "test": "cd exercism-api-tests && bru run --env azure --format junit --output ../report.xml",
+    "change": "cd exercism-api-tests/Change && bru run --env azure --format junit --output ../../report.xml"
   },
   "keywords": [
     "bruno",


### PR DESCRIPTION
This commit introduces new test scenarios for the change making algorithm. These scenarios include making change with Lower Elbonia Coins, possible change without unit coins available, and scenarios where a greedy approach is not optimal. Furthermore, it expands on different scenarios involving large target values and handling edge cases such as no coins making 0 change and handling negative change values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced comprehensive API testing for the change-making algorithm, ensuring it handles various scenarios like non-optimal greedy solutions, unavailable unit coins, and large target values effectively.
  - Added a new automated workflow to execute API tests on Ubuntu, enhancing the reliability of the Bruno application.

- **Tests**
  - New test cases added to verify the change-making algorithm’s response under different conditions, including error handling when no suitable coin combination is available or the target amount is negative.

- **Chores**
  - Updated `package.json` to include a new script for running specific directory tests and managing output locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->